### PR TITLE
fix: Implement stack inspection in Debugger class

### DIFF
--- a/plldb/cli.py
+++ b/plldb/cli.py
@@ -76,7 +76,7 @@ def attach(ctx, stack_name: str):
         ws_client = WebSocketClient(endpoints["websocket_url"], session_id)
 
         # Run the async event loop
-        debugger = Debugger(stack_name=stack_name)
+        debugger = Debugger(session=session, stack_name=stack_name)
         asyncio.run(ws_client.run_loop(debugger.handle_message))
 
     except ValueError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,11 +83,12 @@ def test_attach_command_requires_stack_name(runner):
     assert "Missing option '--stack-name'" in result.output
 
 
+@patch("plldb.cli.Debugger")
 @patch("plldb.cli.StackDiscovery")
 @patch("plldb.cli.RestApiClient")
 @patch("plldb.cli.WebSocketClient")
 @patch("plldb.cli.asyncio.run")
-def test_attach_command_success(mock_asyncio_run, mock_ws_client_class, mock_rest_client_class, mock_discovery_class, runner, mock_aws_session, monkeypatch):
+def test_attach_command_success(mock_asyncio_run, mock_ws_client_class, mock_rest_client_class, mock_discovery_class, mock_debugger_class, runner, mock_aws_session, monkeypatch):
     """Test successful attach command execution."""
 
     # Mock boto3 Session
@@ -113,6 +114,10 @@ def test_attach_command_success(mock_asyncio_run, mock_ws_client_class, mock_res
     mock_ws_client = Mock()
     mock_ws_client_class.return_value = mock_ws_client
 
+    # Mock Debugger
+    mock_debugger = Mock()
+    mock_debugger_class.return_value = mock_debugger
+
     # Run command
     result = runner.invoke(cli, ["attach", "--stack-name", "test-stack"], catch_exceptions=False)
 
@@ -125,6 +130,7 @@ def test_attach_command_success(mock_asyncio_run, mock_ws_client_class, mock_res
     mock_discovery.get_api_endpoints.assert_called_once_with("plldb")
     mock_rest_client.create_session.assert_called_once_with("https://test.execute-api.us-east-1.amazonaws.com/prod", "test-stack")
     mock_ws_client_class.assert_called_once_with("wss://test.execute-api.us-east-1.amazonaws.com/prod", "test-session-id")
+    mock_debugger_class.assert_called_once_with(session=mock_aws_session, stack_name="test-stack")
     mock_asyncio_run.assert_called_once()
 
 

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -1,0 +1,103 @@
+import pytest
+from unittest.mock import MagicMock
+from plldb.debugger import Debugger
+
+
+class TestDebugger:
+    def test_inspect_stack(self, mock_aws_session):
+        # Mock CloudFormation client
+        mock_cfn_client = MagicMock()
+        mock_aws_session.client = MagicMock(return_value=mock_cfn_client)
+
+        # Mock paginator
+        mock_paginator = MagicMock()
+        mock_cfn_client.get_paginator.return_value = mock_paginator
+
+        # Mock describe_stack_resources response
+        mock_paginator.paginate.return_value = [
+            {
+                "StackResources": [
+                    {"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "MyLambdaFunction", "PhysicalResourceId": "my-function-xyz123"},
+                    {"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "AnotherLambda", "PhysicalResourceId": "another-function-abc456"},
+                    {"ResourceType": "AWS::S3::Bucket", "LogicalResourceId": "NotALambda", "PhysicalResourceId": "my-bucket-123"},
+                ]
+            }
+        ]
+
+        # Create debugger instance
+        debugger = Debugger(session=mock_aws_session, stack_name="test-stack")
+
+        # Verify CloudFormation client was called correctly
+        mock_aws_session.client.assert_called_with("cloudformation")
+        mock_cfn_client.get_paginator.assert_called_once_with("describe_stack_resources")
+        mock_paginator.paginate.assert_called_once_with(StackName="test-stack")
+
+        # Verify the lookup table was built correctly (PhysicalResourceId -> LogicalResourceId)
+        assert debugger._lambda_functions_lookup == {"my-function-xyz123": "MyLambdaFunction", "another-function-abc456": "AnotherLambda"}
+
+    def test_inspect_stack_no_lambda_functions(self, mock_aws_session):
+        # Mock CloudFormation client
+        mock_cfn_client = MagicMock()
+        mock_aws_session.client = MagicMock(return_value=mock_cfn_client)
+
+        # Mock paginator
+        mock_paginator = MagicMock()
+        mock_cfn_client.get_paginator.return_value = mock_paginator
+
+        # Mock describe_stack_resources response without Lambda functions
+        mock_paginator.paginate.return_value = [{"StackResources": [{"ResourceType": "AWS::S3::Bucket", "LogicalResourceId": "MyBucket", "PhysicalResourceId": "my-bucket-123"}]}]
+
+        # Create debugger instance
+        debugger = Debugger(session=mock_aws_session, stack_name="test-stack")
+
+        # Verify the lookup table is empty
+        assert debugger._lambda_functions_lookup == {}
+
+    def test_inspect_stack_lambda_without_physical_id(self, mock_aws_session):
+        # Mock CloudFormation client
+        mock_cfn_client = MagicMock()
+        mock_aws_session.client = MagicMock(return_value=mock_cfn_client)
+
+        # Mock paginator
+        mock_paginator = MagicMock()
+        mock_cfn_client.get_paginator.return_value = mock_paginator
+
+        # Mock describe_stack_resources response with Lambda without PhysicalResourceId
+        mock_paginator.paginate.return_value = [
+            {
+                "StackResources": [
+                    {
+                        "ResourceType": "AWS::Lambda::Function",
+                        "LogicalResourceId": "MyLambdaFunction",
+                        # No PhysicalResourceId
+                    }
+                ]
+            }
+        ]
+
+        # Create debugger instance
+        debugger = Debugger(session=mock_aws_session, stack_name="test-stack")
+
+        # Verify the lookup table is empty (no physical ID to map)
+        assert debugger._lambda_functions_lookup == {}
+
+    def test_inspect_stack_multiple_pages(self, mock_aws_session):
+        # Mock CloudFormation client
+        mock_cfn_client = MagicMock()
+        mock_aws_session.client = MagicMock(return_value=mock_cfn_client)
+
+        # Mock paginator
+        mock_paginator = MagicMock()
+        mock_cfn_client.get_paginator.return_value = mock_paginator
+
+        # Mock describe_stack_resources response with multiple pages
+        mock_paginator.paginate.return_value = [
+            {"StackResources": [{"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "Lambda1", "PhysicalResourceId": "function-1"}]},
+            {"StackResources": [{"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "Lambda2", "PhysicalResourceId": "function-2"}]},
+        ]
+
+        # Create debugger instance
+        debugger = Debugger(session=mock_aws_session, stack_name="test-stack")
+
+        # Verify the lookup table contains both functions
+        assert debugger._lambda_functions_lookup == {"function-1": "Lambda1", "function-2": "Lambda2"}


### PR DESCRIPTION
## Summary
- Fixes #7 by implementing the `_inspect_stack` method in the Debugger class
- Uses `describe_stack_resources` API to build PhysicalResourceId -> LogicalResourceId mapping for Lambda functions

## Changes
- Added `session` parameter to Debugger constructor to access AWS services
- Implemented `_inspect_stack()` method that:
  - Uses CloudFormation `describe_stack_resources` with pagination support
  - Filters resources by type `AWS::Lambda::Function`
  - Builds lookup table mapping PhysicalResourceId to LogicalResourceId
- Updated CLI to pass boto3 session to Debugger
- Added comprehensive test coverage with 4 test cases

## Test plan
- [x] Unit tests pass for all stack inspection scenarios
- [x] All existing tests continue to pass
- [x] Code passes type checking (pyright)
- [x] Code formatted with ruff

🤖 Generated with [Claude Code](https://claude.ai/code)