### PR TITLE
fix: Replace describe_stack_resources with list_stack_resources

### DIFF
--- a/plldb/debugger.py
+++ b/plldb/debugger.py
@@ -20,20 +20,20 @@ class Debugger:
     def _inspect_stack(self) -> None:
         """
         Inspect the CloudFormation stack and build lookup table.
-        Use describe_stack_resources to list stack resources.
+        Use list_stack_resources to list stack resources.
         Build associative map from PhysicalResourceId -> LogicalResourceId
         for resource type AWS::Lambda::Function.
         """
         # Create CloudFormation client
         cfn_client = self.session.client("cloudformation")
 
-        # Get all stack resources
-        paginator = cfn_client.get_paginator("describe_stack_resources")
+        # Get all stack resources using list_stack_resources which supports pagination
+        paginator = cfn_client.get_paginator("list_stack_resources")
         page_iterator = paginator.paginate(StackName=self.stack_name)
 
         # Build lookup table of PhysicalResourceId -> LogicalResourceId for Lambda functions
         for page in page_iterator:
-            for resource in page["StackResources"]:
+            for resource in page["StackResourceSummaries"]:
                 if resource["ResourceType"] == "AWS::Lambda::Function":
                     physical_id = resource.get("PhysicalResourceId")
                     logical_id = resource.get("LogicalResourceId")

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -13,10 +13,10 @@ class TestDebugger:
         mock_paginator = MagicMock()
         mock_cfn_client.get_paginator.return_value = mock_paginator
 
-        # Mock describe_stack_resources response
+        # Mock list_stack_resources response
         mock_paginator.paginate.return_value = [
             {
-                "StackResources": [
+                "StackResourceSummaries": [
                     {"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "MyLambdaFunction", "PhysicalResourceId": "my-function-xyz123"},
                     {"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "AnotherLambda", "PhysicalResourceId": "another-function-abc456"},
                     {"ResourceType": "AWS::S3::Bucket", "LogicalResourceId": "NotALambda", "PhysicalResourceId": "my-bucket-123"},
@@ -29,7 +29,7 @@ class TestDebugger:
 
         # Verify CloudFormation client was called correctly
         mock_aws_session.client.assert_called_with("cloudformation")
-        mock_cfn_client.get_paginator.assert_called_once_with("describe_stack_resources")
+        mock_cfn_client.get_paginator.assert_called_once_with("list_stack_resources")
         mock_paginator.paginate.assert_called_once_with(StackName="test-stack")
 
         # Verify the lookup table was built correctly (PhysicalResourceId -> LogicalResourceId)
@@ -44,8 +44,8 @@ class TestDebugger:
         mock_paginator = MagicMock()
         mock_cfn_client.get_paginator.return_value = mock_paginator
 
-        # Mock describe_stack_resources response without Lambda functions
-        mock_paginator.paginate.return_value = [{"StackResources": [{"ResourceType": "AWS::S3::Bucket", "LogicalResourceId": "MyBucket", "PhysicalResourceId": "my-bucket-123"}]}]
+        # Mock list_stack_resources response without Lambda functions
+        mock_paginator.paginate.return_value = [{"StackResourceSummaries": [{"ResourceType": "AWS::S3::Bucket", "LogicalResourceId": "MyBucket", "PhysicalResourceId": "my-bucket-123"}]}]
 
         # Create debugger instance
         debugger = Debugger(session=mock_aws_session, stack_name="test-stack")
@@ -62,10 +62,10 @@ class TestDebugger:
         mock_paginator = MagicMock()
         mock_cfn_client.get_paginator.return_value = mock_paginator
 
-        # Mock describe_stack_resources response with Lambda without PhysicalResourceId
+        # Mock list_stack_resources response with Lambda without PhysicalResourceId
         mock_paginator.paginate.return_value = [
             {
-                "StackResources": [
+                "StackResourceSummaries": [
                     {
                         "ResourceType": "AWS::Lambda::Function",
                         "LogicalResourceId": "MyLambdaFunction",
@@ -90,10 +90,10 @@ class TestDebugger:
         mock_paginator = MagicMock()
         mock_cfn_client.get_paginator.return_value = mock_paginator
 
-        # Mock describe_stack_resources response with multiple pages
+        # Mock list_stack_resources response with multiple pages
         mock_paginator.paginate.return_value = [
-            {"StackResources": [{"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "Lambda1", "PhysicalResourceId": "function-1"}]},
-            {"StackResources": [{"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "Lambda2", "PhysicalResourceId": "function-2"}]},
+            {"StackResourceSummaries": [{"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "Lambda1", "PhysicalResourceId": "function-1"}]},
+            {"StackResourceSummaries": [{"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "Lambda2", "PhysicalResourceId": "function-2"}]},
         ]
 
         # Create debugger instance


### PR DESCRIPTION
## Summary
- Fixed boto3 pagination error when running `plldb attach`
- Replaced `describe_stack_resources` (no pagination support) with `list_stack_resources` (supports pagination)
- Updated tests to match new API response structure

## Test plan
- [x] Run `uv run pytest tests/test_debugger.py -v` - all tests pass
- [x] Run `make test` - all tests pass
- [x] Run `make pyright` - no type errors
- [x] Run `make format` - code is properly formatted

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)