### PR TITLE
Fix: Add IAM policy attachment during Lambda instrumentation

### DIFF
--- a/plldb/cloudformation/lambda_functions/debugger_instrumentation.py
+++ b/plldb/cloudformation/lambda_functions/debugger_instrumentation.py
@@ -56,6 +56,7 @@ def instrument_lambda_functions(stack_name: str, session_id: str, connection_id:
     """Instrument all Lambda functions in the stack with debug configuration."""
     cloudformation = boto3.client("cloudformation")
     lambda_client = boto3.client("lambda")
+    iam_client = boto3.client("iam")
 
     # Send info message that instrumentation has begun
     send_debugger_info(connection_id, session_id, "INFO", f"Starting instrumentation for stack: {stack_name}")
@@ -112,6 +113,35 @@ def instrument_lambda_functions(stack_name: str, session_id: str, connection_id:
                     Layers=layer_arns,
                 )
 
+                # Get the function's execution role
+                function_role_arn = current_config.get("Role")
+                if function_role_arn:
+                    role_name = function_role_arn.split("/")[-1]
+                    
+                    # Create inline policy to allow assuming PLLDBDebuggerRole
+                    account_id = boto3.client("sts").get_caller_identity()["Account"]
+                    policy_document = {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": "sts:AssumeRole",
+                                "Resource": f"arn:aws:iam::{account_id}:role/PLLDBDebuggerRole"
+                            }
+                        ]
+                    }
+                    
+                    try:
+                        iam_client.put_role_policy(
+                            RoleName=role_name,
+                            PolicyName="PLLDBAssumeRolePolicy",
+                            PolicyDocument=json.dumps(policy_document)
+                        )
+                        logger.info(f"Added assume role policy to {role_name}")
+                    except Exception as e:
+                        logger.warning(f"Failed to add assume role policy to {role_name}: {e}")
+                        send_debugger_info(connection_id, session_id, "WARNING", f"Could not add assume role policy to {role_name}: {e}")
+
                 logger.info(f"Successfully instrumented: {function_name}")
                 send_debugger_info(connection_id, session_id, "INFO", f"Instrumented Lambda function: {function_name}")
 
@@ -134,6 +164,7 @@ def uninstrument_lambda_functions(stack_name: str, session_id: Optional[str] = N
     """Remove debug instrumentation from all Lambda functions in the stack."""
     cloudformation = boto3.client("cloudformation")
     lambda_client = boto3.client("lambda")
+    iam_client = boto3.client("iam")
 
     # Send info message that de-instrumentation has begun (if connection details provided)
     if connection_id and session_id:
@@ -183,6 +214,24 @@ def uninstrument_lambda_functions(stack_name: str, session_id: Optional[str] = N
                     update_params["Layers"] = []
 
                 lambda_client.update_function_configuration(**update_params)
+
+                # Remove the inline policy that allows assuming PLLDBDebuggerRole
+                function_role_arn = current_config.get("Role")
+                if function_role_arn:
+                    role_name = function_role_arn.split("/")[-1]
+                    
+                    try:
+                        iam_client.delete_role_policy(
+                            RoleName=role_name,
+                            PolicyName="PLLDBAssumeRolePolicy"
+                        )
+                        logger.info(f"Removed assume role policy from {role_name}")
+                    except iam_client.exceptions.NoSuchEntityException:
+                        logger.debug(f"Policy PLLDBAssumeRolePolicy not found on role {role_name}")
+                    except Exception as e:
+                        logger.warning(f"Failed to remove assume role policy from {role_name}: {e}")
+                        if connection_id and session_id:
+                            send_debugger_info(connection_id, session_id, "WARNING", f"Could not remove assume role policy from {role_name}: {e}")
 
                 logger.info(f"Successfully uninstrumented: {function_name}")
                 if connection_id and session_id:

--- a/plldb/cloudformation/lambda_functions/debugger_instrumentation.py
+++ b/plldb/cloudformation/lambda_functions/debugger_instrumentation.py
@@ -117,26 +117,13 @@ def instrument_lambda_functions(stack_name: str, session_id: str, connection_id:
                 function_role_arn = current_config.get("Role")
                 if function_role_arn:
                     role_name = function_role_arn.split("/")[-1]
-                    
+
                     # Create inline policy to allow assuming PLLDBDebuggerRole
                     account_id = boto3.client("sts").get_caller_identity()["Account"]
-                    policy_document = {
-                        "Version": "2012-10-17",
-                        "Statement": [
-                            {
-                                "Effect": "Allow",
-                                "Action": "sts:AssumeRole",
-                                "Resource": f"arn:aws:iam::{account_id}:role/PLLDBDebuggerRole"
-                            }
-                        ]
-                    }
-                    
+                    policy_document = {"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "sts:AssumeRole", "Resource": f"arn:aws:iam::{account_id}:role/PLLDBDebuggerRole"}]}
+
                     try:
-                        iam_client.put_role_policy(
-                            RoleName=role_name,
-                            PolicyName="PLLDBAssumeRolePolicy",
-                            PolicyDocument=json.dumps(policy_document)
-                        )
+                        iam_client.put_role_policy(RoleName=role_name, PolicyName="PLLDBAssumeRolePolicy", PolicyDocument=json.dumps(policy_document))
                         logger.info(f"Added assume role policy to {role_name}")
                     except Exception as e:
                         logger.warning(f"Failed to add assume role policy to {role_name}: {e}")
@@ -219,12 +206,9 @@ def uninstrument_lambda_functions(stack_name: str, session_id: Optional[str] = N
                 function_role_arn = current_config.get("Role")
                 if function_role_arn:
                     role_name = function_role_arn.split("/")[-1]
-                    
+
                     try:
-                        iam_client.delete_role_policy(
-                            RoleName=role_name,
-                            PolicyName="PLLDBAssumeRolePolicy"
-                        )
+                        iam_client.delete_role_policy(RoleName=role_name, PolicyName="PLLDBAssumeRolePolicy")
                         logger.info(f"Removed assume role policy from {role_name}")
                     except iam_client.exceptions.NoSuchEntityException:
                         logger.debug(f"Policy PLLDBAssumeRolePolicy not found on role {role_name}")

--- a/plldb/cloudformation/template.yaml
+++ b/plldb/cloudformation/template.yaml
@@ -121,6 +121,13 @@ Resources:
                   - 'execute-api:ManageConnections'
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PLLDBWebSocketAPI}/*'
+              - Effect: Allow
+                Action:
+                  - 'iam:PutRolePolicy'
+                  - 'iam:DeleteRolePolicy'
+                  - 'iam:GetRole'
+                  - 'iam:GetRolePolicy'
+                Resource: '*'
 
   PLLDBDebuggerRole:
     Type: AWS::IAM::Role

--- a/tests/test_debugger_instrumentation.py
+++ b/tests/test_debugger_instrumentation.py
@@ -29,7 +29,10 @@ def mock_aws_services():
         # Mock Lambda client
         mock_lambda_client = MagicMock()
         # Return different configs for each function
-        mock_lambda_client.get_function_configuration.side_effect = [{"Environment": {"Variables": {}}, "Layers": []}, {"Environment": {"Variables": {}}, "Layers": []}]
+        mock_lambda_client.get_function_configuration.side_effect = [
+            {"Environment": {"Variables": {}}, "Layers": [], "Role": "arn:aws:iam::123456789012:role/test-function-1-role"},
+            {"Environment": {"Variables": {}}, "Layers": [], "Role": "arn:aws:iam::123456789012:role/test-function-2-role"}
+        ]
         # Mock list_layer_versions for get_latest_layer_version
         mock_lambda_client.list_layer_versions.return_value = {
             "LayerVersions": [
@@ -39,18 +42,30 @@ def mock_aws_services():
             ]
         }
 
+        # Mock IAM client
+        mock_iam_client = MagicMock()
+        mock_iam_client.exceptions.NoSuchEntityException = Exception
+
+        # Mock STS client
+        mock_sts_client = MagicMock()
+        mock_sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
+
         # Configure boto3.client to return appropriate mocks
         def get_client(service):
             if service == "cloudformation":
                 return mock_cf_client
             elif service == "lambda":
                 return mock_lambda_client
+            elif service == "iam":
+                return mock_iam_client
+            elif service == "sts":
+                return mock_sts_client
             else:
                 raise ValueError(f"Unexpected service: {service}")
 
         mock_boto3.client.side_effect = get_client
 
-        yield {"boto3": mock_boto3, "cf_client": mock_cf_client, "lambda_client": mock_lambda_client}
+        yield {"boto3": mock_boto3, "cf_client": mock_cf_client, "lambda_client": mock_lambda_client, "iam_client": mock_iam_client, "sts_client": mock_sts_client}
 
 
 class TestGetLatestLayerVersion:
@@ -115,6 +130,23 @@ class TestInstrumentLambdaFunctions:
             assert kwargs["Environment"]["Variables"]["DEBUGGER_CONNECTION_ID"] == "connection-456"
             assert kwargs["Environment"]["Variables"]["AWS_LAMBDA_EXEC_WRAPPER"] == "/opt/bin/bootstrap"
             assert "arn:aws:lambda:us-east-1:123456789012:layer:PLLDBDebuggerRuntime:3" in kwargs["Layers"]
+        
+        # Verify IAM policy was added - should be called twice (for two functions)
+        assert mock_aws_services["iam_client"].put_role_policy.call_count == 2
+        
+        # Check the IAM policy calls
+        iam_calls = mock_aws_services["iam_client"].put_role_policy.call_args_list
+        for i, call in enumerate(iam_calls):
+            args, kwargs = call
+            expected_role = f"test-function-{i+1}-role"
+            assert kwargs["RoleName"] == expected_role
+            assert kwargs["PolicyName"] == "PLLDBAssumeRolePolicy"
+            policy_doc = json.loads(kwargs["PolicyDocument"])
+            assert policy_doc["Version"] == "2012-10-17"
+            assert len(policy_doc["Statement"]) == 1
+            assert policy_doc["Statement"][0]["Effect"] == "Allow"
+            assert policy_doc["Statement"][0]["Action"] == "sts:AssumeRole"
+            assert policy_doc["Statement"][0]["Resource"] == "arn:aws:iam::123456789012:role/PLLDBDebuggerRole"
 
     def test_instrument_lambda_functions_idempotent(self, mock_aws_services):
         """Test that instrumentation is idempotent."""
@@ -158,10 +190,12 @@ class TestUninstrumentLambdaFunctions:
             {
                 "Environment": {"Variables": {"DEBUGGER_SESSION_ID": "session-123", "DEBUGGER_CONNECTION_ID": "connection-456", "AWS_LAMBDA_EXEC_WRAPPER": "/opt/bin/bootstrap", "OTHER_VAR": "value"}},
                 "Layers": [{"Arn": "arn:aws:lambda:us-east-1:123456789012:layer:PLLDBDebuggerRuntime:2"}, {"Arn": "arn:aws:lambda:us-east-1:123456789012:layer:OtherLayer:1"}],
+                "Role": "arn:aws:iam::123456789012:role/test-function-1-role"
             },
             {
                 "Environment": {"Variables": {"DEBUGGER_SESSION_ID": "session-123", "DEBUGGER_CONNECTION_ID": "connection-456", "AWS_LAMBDA_EXEC_WRAPPER": "/opt/bin/bootstrap", "OTHER_VAR": "value"}},
                 "Layers": [{"Arn": "arn:aws:lambda:us-east-1:123456789012:layer:PLLDBDebuggerRuntime:2"}, {"Arn": "arn:aws:lambda:us-east-1:123456789012:layer:OtherLayer:1"}],
+                "Role": "arn:aws:iam::123456789012:role/test-function-2-role"
             },
         ]
 
@@ -183,6 +217,17 @@ class TestUninstrumentLambdaFunctions:
             # Should remove only the debug layer
             assert len(kwargs["Layers"]) == 1
             assert kwargs["Layers"][0] == "arn:aws:lambda:us-east-1:123456789012:layer:OtherLayer:1"
+            
+        # Verify IAM policy was removed - should be called twice (for two functions)
+        assert mock_aws_services["iam_client"].delete_role_policy.call_count == 2
+        
+        # Check the IAM policy deletion calls
+        iam_calls = mock_aws_services["iam_client"].delete_role_policy.call_args_list
+        for i, call in enumerate(iam_calls):
+            args, kwargs = call
+            expected_role = f"test-function-{i+1}-role"
+            assert kwargs["RoleName"] == expected_role
+            assert kwargs["PolicyName"] == "PLLDBAssumeRolePolicy"
 
     def test_uninstrument_lambda_functions_idempotent(self, mock_aws_services):
         """Test that uninstrumentation is idempotent."""

--- a/tests/test_debugger_instrumentation.py
+++ b/tests/test_debugger_instrumentation.py
@@ -31,7 +31,7 @@ def mock_aws_services():
         # Return different configs for each function
         mock_lambda_client.get_function_configuration.side_effect = [
             {"Environment": {"Variables": {}}, "Layers": [], "Role": "arn:aws:iam::123456789012:role/test-function-1-role"},
-            {"Environment": {"Variables": {}}, "Layers": [], "Role": "arn:aws:iam::123456789012:role/test-function-2-role"}
+            {"Environment": {"Variables": {}}, "Layers": [], "Role": "arn:aws:iam::123456789012:role/test-function-2-role"},
         ]
         # Mock list_layer_versions for get_latest_layer_version
         mock_lambda_client.list_layer_versions.return_value = {
@@ -130,15 +130,15 @@ class TestInstrumentLambdaFunctions:
             assert kwargs["Environment"]["Variables"]["DEBUGGER_CONNECTION_ID"] == "connection-456"
             assert kwargs["Environment"]["Variables"]["AWS_LAMBDA_EXEC_WRAPPER"] == "/opt/bin/bootstrap"
             assert "arn:aws:lambda:us-east-1:123456789012:layer:PLLDBDebuggerRuntime:3" in kwargs["Layers"]
-        
+
         # Verify IAM policy was added - should be called twice (for two functions)
         assert mock_aws_services["iam_client"].put_role_policy.call_count == 2
-        
+
         # Check the IAM policy calls
         iam_calls = mock_aws_services["iam_client"].put_role_policy.call_args_list
         for i, call in enumerate(iam_calls):
             args, kwargs = call
-            expected_role = f"test-function-{i+1}-role"
+            expected_role = f"test-function-{i + 1}-role"
             assert kwargs["RoleName"] == expected_role
             assert kwargs["PolicyName"] == "PLLDBAssumeRolePolicy"
             policy_doc = json.loads(kwargs["PolicyDocument"])
@@ -190,12 +190,12 @@ class TestUninstrumentLambdaFunctions:
             {
                 "Environment": {"Variables": {"DEBUGGER_SESSION_ID": "session-123", "DEBUGGER_CONNECTION_ID": "connection-456", "AWS_LAMBDA_EXEC_WRAPPER": "/opt/bin/bootstrap", "OTHER_VAR": "value"}},
                 "Layers": [{"Arn": "arn:aws:lambda:us-east-1:123456789012:layer:PLLDBDebuggerRuntime:2"}, {"Arn": "arn:aws:lambda:us-east-1:123456789012:layer:OtherLayer:1"}],
-                "Role": "arn:aws:iam::123456789012:role/test-function-1-role"
+                "Role": "arn:aws:iam::123456789012:role/test-function-1-role",
             },
             {
                 "Environment": {"Variables": {"DEBUGGER_SESSION_ID": "session-123", "DEBUGGER_CONNECTION_ID": "connection-456", "AWS_LAMBDA_EXEC_WRAPPER": "/opt/bin/bootstrap", "OTHER_VAR": "value"}},
                 "Layers": [{"Arn": "arn:aws:lambda:us-east-1:123456789012:layer:PLLDBDebuggerRuntime:2"}, {"Arn": "arn:aws:lambda:us-east-1:123456789012:layer:OtherLayer:1"}],
-                "Role": "arn:aws:iam::123456789012:role/test-function-2-role"
+                "Role": "arn:aws:iam::123456789012:role/test-function-2-role",
             },
         ]
 
@@ -217,15 +217,15 @@ class TestUninstrumentLambdaFunctions:
             # Should remove only the debug layer
             assert len(kwargs["Layers"]) == 1
             assert kwargs["Layers"][0] == "arn:aws:lambda:us-east-1:123456789012:layer:OtherLayer:1"
-            
+
         # Verify IAM policy was removed - should be called twice (for two functions)
         assert mock_aws_services["iam_client"].delete_role_policy.call_count == 2
-        
+
         # Check the IAM policy deletion calls
         iam_calls = mock_aws_services["iam_client"].delete_role_policy.call_args_list
         for i, call in enumerate(iam_calls):
             args, kwargs = call
-            expected_role = f"test-function-{i+1}-role"
+            expected_role = f"test-function-{i + 1}-role"
             assert kwargs["RoleName"] == expected_role
             assert kwargs["PolicyName"] == "PLLDBAssumeRolePolicy"
 


### PR DESCRIPTION
## Summary
- Fixes #11 by adding IAM policy attachment during Lambda instrumentation
- Lambda functions can now successfully assume the PLLDBDebuggerRole

## Changes
- Added IAM policy management permissions (`iam:PutRolePolicy`, `iam:DeleteRolePolicy`, etc.) to PLLDBServiceRole in CloudFormation template
- During instrumentation, attach an inline policy (`PLLDBAssumeRolePolicy`) to each Lambda function's execution role that allows it to assume PLLDBDebuggerRole
- During de-instrumentation, remove the inline policy
- Added comprehensive tests to verify IAM policy management works correctly

## Test plan
- [x] All existing tests pass
- [x] Added new tests for IAM policy attachment/detachment
- [x] Type checking with pyright passes

🤖 Generated with [Claude Code](https://claude.ai/code)