### PR TITLE
fix: Add DynamoDB UpdateItem permission for PLLDBDebugger table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - When fixing github issues, always create new branch for it, called issue/gh-<issue-id>
 - Before committing, run `make format` to format codebase
 - Pre-commit hooks are configured to run `make format`, `make pyright`, and `make test` automatically
+- Always link fixed GH issue into PR
 
 ## Commands
 

--- a/plldb/cloudformation/template.yaml
+++ b/plldb/cloudformation/template.yaml
@@ -110,6 +110,8 @@ Resources:
                 Resource:
                   - !GetAtt PLLDBSessions.Arn
                   - !Sub '${PLLDBSessions.Arn}/index/*'
+                  - !GetAtt PLLDBDebugger.Arn
+                  - !Sub '${PLLDBDebugger.Arn}/index/*'
               - Effect: Allow
                 Action:
                   - 'cloudformation:ListStackResources'


### PR DESCRIPTION
## Summary
- Fixed AccessDenied error when WebSocket handler tries to store debugging responses
- Added missing DynamoDB permissions for PLLDBDebugger table in PLLDBServiceRole

## Details
The PLLDBServiceRole was missing permissions to update items in the PLLDBDebugger table, causing AccessDenied errors when the websocket_default handler tried to store debugging responses.

Added PLLDBDebugger table ARN and its indexes to the DynamoDB permissions in PLLDBServicePolicy.

## Test plan
- [x] All existing tests pass
- [x] Code formatted with `make format`
- [x] Pre-commit hooks pass

Fixes #15

🤖 Generated with [Claude Code](https://claude.ai/code)